### PR TITLE
feat: add configurable empty changelog output

### DIFF
--- a/src/__snapshots__/changelog.test.ts.snap
+++ b/src/__snapshots__/changelog.test.ts.snap
@@ -332,14 +332,14 @@ Object {
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-custom.json, type-breaking.json, sortOrder: asc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "custom1",
 }
 `;
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-custom.json, type-breaking.json, sortOrder: desc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "custom1",
 }
 `;
@@ -378,14 +378,14 @@ Object {
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-empty.json, type-breaking.json, sortOrder: asc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "",
 }
 `;
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-empty.json, type-breaking.json, sortOrder: desc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "",
 }
 `;
@@ -424,14 +424,14 @@ Object {
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-semver.json, type-breaking.json, sortOrder: asc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "minor",
 }
 `;
 
 exports[`changelog.ts generateChangelog correctly generates the changelog with: commits-non-breaking.json, bump-semver.json, type-breaking.json, sortOrder: desc 1`] = `
 Object {
-  "body": "",
+  "body": "No changes",
   "bump": "minor",
 }
 `;

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -78,6 +78,7 @@ type GenerateChangelog = (params: {
   typeLabels: GroupLabel[];
   bumpLabels: GroupLabel[];
   sortOrder?: SortOrder;
+  emptyMessage?: string;
 }) => Changelog;
 
 export const generateChangelog: GenerateChangelog = ({
@@ -86,24 +87,26 @@ export const generateChangelog: GenerateChangelog = ({
   typeLabels,
   bumpLabels,
   sortOrder = 'desc',
+  emptyMessage = 'No changes',
 }) => {
   const indexedByType = indexByType(commits);
   const mapCommit = (commit: Commit) => commitToChagelogLine(commit, issuesUrl);
-  const body = typeLabels
-    .map(({ title, types }) => {
-      const typeCommits = types
-        .map((type) => indexedByType[type] || [])
-        .flat()
-        .sort(commitSortBy[sortOrder]);
+  const body =
+    typeLabels
+      .map(({ title, types }) => {
+        const typeCommits = types
+          .map((type) => indexedByType[type] || [])
+          .flat()
+          .sort(commitSortBy[sortOrder]);
 
-      if (!typeCommits.length) {
-        return null;
-      }
+        if (!typeCommits.length) {
+          return null;
+        }
 
-      return [`## ${title}`, ...typeCommits.map(mapCommit)].join('\n');
-    })
-    .filter((block) => block !== null)
-    .join('\n\n');
+        return [`## ${title}`, ...typeCommits.map(mapCommit)].join('\n');
+      })
+      .filter((block) => block !== null)
+      .join('\n\n') || emptyMessage;
   const bump = calculateBump(indexedByType, bumpLabels);
 
   return {

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -32,5 +32,6 @@
     }
   ],
   "issuesUrl": "",
-  "sortOrder": "desc"
+  "sortOrder": "desc",
+  "emptyMessage": "No changes"
 }


### PR DESCRIPTION
Adds a configurable message if the changelog is empty. Per default it is

> No changes